### PR TITLE
Add support for countryCode and scriptCode

### DIFF
--- a/example/assets/locale/fi-FI.json
+++ b/example/assets/locale/fi-FI.json
@@ -1,0 +1,9 @@
+{
+  "test": "Näet lisää napauttamalla kuvakkeita",
+  "test_arg1": "Lisää napauttamalla %1$s",
+  "test_arg2": "Lisää napauttamalla %1$d",
+  "test_arg3": "Lisää napauttamalla %1$s %2$d",
+  "test_arg4": "Lisää napauttamalla %1$s %2$d %1$s",
+  "welcome_message": "Lisää napauttamalla",
+  "test_new_line": "Lisää\nLisää napauttamalla\n\n%1$s %2$d %1$s"
+}

--- a/example/assets/locale/zh-Hans-CN.json
+++ b/example/assets/locale/zh-Hans-CN.json
@@ -1,0 +1,8 @@
+{
+  "test": "视频的灯光脚本",
+  "test_arg1": "频的 %1$s",
+  "test_arg2": "频的 %1$d",
+  "test_arg3": "频的 %1$s %2$d",
+  "test_arg4": "频的 %1$s %2$d %1$s",
+  "test_new_line": "频\n的\n\n%1$s %2$d %1$s"
+}

--- a/example/lib/util/locale/localization.dart
+++ b/example/lib/util/locale/localization.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:intl/locale.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:locale_gen_example/util/locale/localization_keys.dart';
@@ -10,20 +11,15 @@ import 'package:locale_gen_example/util/locale/localization_keys.dart';
 class Localization {
   Map<String, dynamic> _localisedValues = <String, dynamic>{};
 
-  static Localization of(BuildContext context) =>
-      Localizations.of<Localization>(context, Localization)!;
+  static Localization of(BuildContext context) => Localizations.of<Localization>(context, Localization)!;
 
-  static Future<Localization> load(Locale locale,
-      {bool showLocalizationKeys = false, bool useCaching = true}) async {
+  static Future<Localization> load(Locale locale, {bool showLocalizationKeys = false, bool useCaching = true}) async {
     final localizations = Localization();
     if (showLocalizationKeys) {
       return localizations;
     }
-    final jsonContent = await rootBundle.loadString(
-        'assets/locale/${locale.languageCode}.json',
-        cache: useCaching);
-    localizations._localisedValues =
-        json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as
+    final jsonContent = await rootBundle.loadString('assets/locale/${locale.languageCode}.json', cache: useCaching);
+    localizations._localisedValues = json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as
     return localizations;
   }
 
@@ -34,8 +30,7 @@ class Localization {
       if (args == null || args.isEmpty) return value;
       var newValue = value;
       // ignore: avoid_annotating_with_dynamic
-      args.asMap().forEach((index, dynamic arg) =>
-          newValue = _replaceWith(newValue, arg, index + 1));
+      args.asMap().forEach((index, dynamic arg) => newValue = _replaceWith(newValue, arg, index + 1));
       return newValue;
     } catch (e) {
       return '⚠$key⚠';
@@ -57,6 +52,10 @@ class Localization {
   /// en:  **'Testing in English'**
   ///
   /// nl:  **'Test in het Nederlands'**
+  ///
+  /// zh-Hans-CN: **'视频的灯光脚本'**
+  ///
+  /// fi-FI: **'Näet lisää napauttamalla kuvakkeita'**
   String get test => _t(LocalizationKeys.test);
 
   /// Translations:
@@ -64,41 +63,56 @@ class Localization {
   /// en:  **'Testing argument %1$s'**
   ///
   /// nl:  **'Test argument %1$s'**
-  String testArg1(String arg1) =>
-      _t(LocalizationKeys.testArg1, args: <dynamic>[arg1]);
+  ///
+  /// zh-Hans-CN: **'频的 %1$s'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$s'**
+  String testArg1(String arg1) => _t(LocalizationKeys.testArg1, args: <dynamic>[arg1]);
 
   /// Translations:
   ///
   /// en:  **'Testing argument %1$d'**
   ///
   /// nl:  **'Test argument %1$d'**
-  String testArg2(num arg1) =>
-      _t(LocalizationKeys.testArg2, args: <dynamic>[arg1]);
+  ///
+  /// zh-Hans-CN: **'频的 %1$d'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$d'**
+  String testArg2(num arg1) => _t(LocalizationKeys.testArg2, args: <dynamic>[arg1]);
 
   /// Translations:
   ///
   /// en:  **'Testing argument %1$s %2$d'**
   ///
   /// nl:  **'Test argument %1$s %2$d'**
-  String testArg3(String arg1, num arg2) =>
-      _t(LocalizationKeys.testArg3, args: <dynamic>[arg1, arg2]);
+  ///
+  /// zh-Hans-CN: **'频的 %1$s %2$d'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$s %2$d'**
+  String testArg3(String arg1, num arg2) => _t(LocalizationKeys.testArg3, args: <dynamic>[arg1, arg2]);
 
   /// Translations:
   ///
   /// en:  **'Testing argument %1$s %2$d %1$s'**
   ///
   /// nl:  **'Test argument %1$s %2$d %1$s'**
-  String testArg4(String arg1, num arg2) =>
-      _t(LocalizationKeys.testArg4, args: <dynamic>[arg1, arg2]);
+  ///
+  /// zh-Hans-CN: **'频的 %1$s %2$d %1$s'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$s %2$d %1$s'**
+  String testArg4(String arg1, num arg2) => _t(LocalizationKeys.testArg4, args: <dynamic>[arg1, arg2]);
 
   /// Translations:
   ///
   /// en:  **'Testing\nargument\n\n%1$s %2$d %1$s'**
   ///
   /// nl:  **'Test\nargument\n\n%1$s %2$d %1$s'**
-  String testNewLine(String arg1, num arg2) =>
-      _t(LocalizationKeys.testNewLine, args: <dynamic>[arg1, arg2]);
+  ///
+  /// zh-Hans-CN: **'频\n的\n\n%1$s %2$d %1$s'**
+  ///
+  /// fi-FI: **'Lisää\nLisää napauttamalla\n\n%1$s %2$d %1$s'**
+  String testNewLine(String arg1, num arg2) => _t(LocalizationKeys.testNewLine, args: <dynamic>[arg1, arg2]);
 
-  String getTranslation(String key, {List<dynamic>? args}) =>
-      _t(key, args: args ?? <dynamic>[]);
+  String getTranslation(String key, {List<dynamic>? args}) => _t(key, args: args ?? <dynamic>[]);
+
 }

--- a/example/lib/util/locale/localization.dart
+++ b/example/lib/util/locale/localization.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:intl/locale.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:locale_gen_example/util/locale/localization_keys.dart';

--- a/example/lib/util/locale/localization.dart
+++ b/example/lib/util/locale/localization.dart
@@ -11,15 +11,20 @@ import 'package:locale_gen_example/util/locale/localization_keys.dart';
 class Localization {
   Map<String, dynamic> _localisedValues = <String, dynamic>{};
 
-  static Localization of(BuildContext context) => Localizations.of<Localization>(context, Localization)!;
+  static Localization of(BuildContext context) =>
+      Localizations.of<Localization>(context, Localization)!;
 
-  static Future<Localization> load(Locale locale, {bool showLocalizationKeys = false, bool useCaching = true}) async {
+  static Future<Localization> load(Locale locale,
+      {bool showLocalizationKeys = false, bool useCaching = true}) async {
     final localizations = Localization();
     if (showLocalizationKeys) {
       return localizations;
     }
-    final jsonContent = await rootBundle.loadString('assets/locale/${locale.languageCode}.json', cache: useCaching);
-    localizations._localisedValues = json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as
+    final jsonContent = await rootBundle.loadString(
+        'assets/locale/${locale.languageCode}.json',
+        cache: useCaching);
+    localizations._localisedValues =
+        json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as
     return localizations;
   }
 
@@ -30,7 +35,8 @@ class Localization {
       if (args == null || args.isEmpty) return value;
       var newValue = value;
       // ignore: avoid_annotating_with_dynamic
-      args.asMap().forEach((index, dynamic arg) => newValue = _replaceWith(newValue, arg, index + 1));
+      args.asMap().forEach((index, dynamic arg) =>
+          newValue = _replaceWith(newValue, arg, index + 1));
       return newValue;
     } catch (e) {
       return '⚠$key⚠';
@@ -67,7 +73,8 @@ class Localization {
   /// zh-Hans-CN: **'频的 %1$s'**
   ///
   /// fi-FI: **'Lisää napauttamalla %1$s'**
-  String testArg1(String arg1) => _t(LocalizationKeys.testArg1, args: <dynamic>[arg1]);
+  String testArg1(String arg1) =>
+      _t(LocalizationKeys.testArg1, args: <dynamic>[arg1]);
 
   /// Translations:
   ///
@@ -78,7 +85,8 @@ class Localization {
   /// zh-Hans-CN: **'频的 %1$d'**
   ///
   /// fi-FI: **'Lisää napauttamalla %1$d'**
-  String testArg2(num arg1) => _t(LocalizationKeys.testArg2, args: <dynamic>[arg1]);
+  String testArg2(num arg1) =>
+      _t(LocalizationKeys.testArg2, args: <dynamic>[arg1]);
 
   /// Translations:
   ///
@@ -89,7 +97,8 @@ class Localization {
   /// zh-Hans-CN: **'频的 %1$s %2$d'**
   ///
   /// fi-FI: **'Lisää napauttamalla %1$s %2$d'**
-  String testArg3(String arg1, num arg2) => _t(LocalizationKeys.testArg3, args: <dynamic>[arg1, arg2]);
+  String testArg3(String arg1, num arg2) =>
+      _t(LocalizationKeys.testArg3, args: <dynamic>[arg1, arg2]);
 
   /// Translations:
   ///
@@ -100,7 +109,8 @@ class Localization {
   /// zh-Hans-CN: **'频的 %1$s %2$d %1$s'**
   ///
   /// fi-FI: **'Lisää napauttamalla %1$s %2$d %1$s'**
-  String testArg4(String arg1, num arg2) => _t(LocalizationKeys.testArg4, args: <dynamic>[arg1, arg2]);
+  String testArg4(String arg1, num arg2) =>
+      _t(LocalizationKeys.testArg4, args: <dynamic>[arg1, arg2]);
 
   /// Translations:
   ///
@@ -111,8 +121,9 @@ class Localization {
   /// zh-Hans-CN: **'频\n的\n\n%1$s %2$d %1$s'**
   ///
   /// fi-FI: **'Lisää\nLisää napauttamalla\n\n%1$s %2$d %1$s'**
-  String testNewLine(String arg1, num arg2) => _t(LocalizationKeys.testNewLine, args: <dynamic>[arg1, arg2]);
+  String testNewLine(String arg1, num arg2) =>
+      _t(LocalizationKeys.testNewLine, args: <dynamic>[arg1, arg2]);
 
-  String getTranslation(String key, {List<dynamic>? args}) => _t(key, args: args ?? <dynamic>[]);
-
+  String getTranslation(String key, {List<dynamic>? args}) =>
+      _t(key, args: args ?? <dynamic>[]);
 }

--- a/example/lib/util/locale/localization_delegate.dart
+++ b/example/lib/util/locale/localization_delegate.dart
@@ -16,25 +16,25 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
   static const _supportedLanguages = [
     'en',
     'nl',
+    'zh',
+    'fi',
   ];
 
   static const _supportedLocales = [
-    Locale('en'),
-    Locale('nl'),
+    Locale.fromSubtags(languageCode: 'en', scriptCode: null, countryCode: null),
+    Locale.fromSubtags(languageCode: 'nl', scriptCode: null, countryCode: null),
+    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'),
+    Locale.fromSubtags(languageCode: 'fi', scriptCode: null, countryCode: 'FI'),
   ];
 
   static List<String> get supportedLanguages {
     if (localeFilter == null) return _supportedLanguages;
-    return _supportedLanguages
-        .where((element) => localeFilter?.call(element) ?? true)
-        .toList();
+    return _supportedLanguages.where((element) => localeFilter?.call(element) ?? true).toList();
   }
 
   static List<Locale> get supportedLocales {
     if (localeFilter == null) return _supportedLocales;
-    return _supportedLocales
-        .where((element) => localeFilter?.call(element.languageCode) ?? true)
-        .toList();
+    return _supportedLocales.where((element) => localeFilter?.call(element.languageCode) ?? true).toList();
   }
 
   Locale? newLocale;
@@ -42,25 +42,20 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
   final bool useCaching;
   bool showLocalizationKeys;
 
-  LocalizationDelegate(
-      {this.newLocale,
-      this.showLocalizationKeys = false,
-      this.useCaching = !kDebugMode}) {
+  LocalizationDelegate({this.newLocale, this.showLocalizationKeys = false, this.useCaching = !kDebugMode}) {
     if (newLocale != null) {
       activeLocale = newLocale;
     }
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      supportedLanguages.contains(locale.languageCode);
+  bool isSupported(Locale locale) => supportedLanguages.contains(locale.languageCode);
 
   @override
   Future<Localization> load(Locale locale) async {
     final newActiveLocale = newLocale ?? locale;
     activeLocale = newActiveLocale;
-    return Localization.load(newActiveLocale,
-        showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);
+    return Localization.load(newActiveLocale, showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);
   }
 
   @override

--- a/example/lib/util/locale/localization_delegate.dart
+++ b/example/lib/util/locale/localization_delegate.dart
@@ -23,18 +23,23 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
   static const _supportedLocales = [
     Locale.fromSubtags(languageCode: 'en', scriptCode: null, countryCode: null),
     Locale.fromSubtags(languageCode: 'nl', scriptCode: null, countryCode: null),
-    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'),
+    Locale.fromSubtags(
+        languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'),
     Locale.fromSubtags(languageCode: 'fi', scriptCode: null, countryCode: 'FI'),
   ];
 
   static List<String> get supportedLanguages {
     if (localeFilter == null) return _supportedLanguages;
-    return _supportedLanguages.where((element) => localeFilter?.call(element) ?? true).toList();
+    return _supportedLanguages
+        .where((element) => localeFilter?.call(element) ?? true)
+        .toList();
   }
 
   static List<Locale> get supportedLocales {
     if (localeFilter == null) return _supportedLocales;
-    return _supportedLocales.where((element) => localeFilter?.call(element.languageCode) ?? true).toList();
+    return _supportedLocales
+        .where((element) => localeFilter?.call(element.languageCode) ?? true)
+        .toList();
   }
 
   Locale? newLocale;
@@ -42,20 +47,25 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
   final bool useCaching;
   bool showLocalizationKeys;
 
-  LocalizationDelegate({this.newLocale, this.showLocalizationKeys = false, this.useCaching = !kDebugMode}) {
+  LocalizationDelegate(
+      {this.newLocale,
+      this.showLocalizationKeys = false,
+      this.useCaching = !kDebugMode}) {
     if (newLocale != null) {
       activeLocale = newLocale;
     }
   }
 
   @override
-  bool isSupported(Locale locale) => supportedLanguages.contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      supportedLanguages.contains(locale.languageCode);
 
   @override
   Future<Localization> load(Locale locale) async {
     final newActiveLocale = newLocale ?? locale;
     activeLocale = newActiveLocale;
-    return Localization.load(newActiveLocale, showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);
+    return Localization.load(newActiveLocale,
+        showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);
   }
 
   @override

--- a/example/lib/util/locale/localization_keys.dart
+++ b/example/lib/util/locale/localization_keys.dart
@@ -2,7 +2,6 @@
 //THIS FILE IS AUTO GENERATED. DO NOT EDIT//
 //============================================================//
 class LocalizationKeys {
-
   /// Translations:
   ///
   /// en:  **'Testing in English'**
@@ -68,5 +67,4 @@ class LocalizationKeys {
   ///
   /// fi-FI: **'Lisää\nLisää napauttamalla\n\n%1$s %2$d %1$s'**
   static const testNewLine = 'test_new_line';
-
 }

--- a/example/lib/util/locale/localization_keys.dart
+++ b/example/lib/util/locale/localization_keys.dart
@@ -2,11 +2,16 @@
 //THIS FILE IS AUTO GENERATED. DO NOT EDIT//
 //============================================================//
 class LocalizationKeys {
+
   /// Translations:
   ///
   /// en:  **'Testing in English'**
   ///
   /// nl:  **'Test in het Nederlands'**
+  ///
+  /// zh-Hans-CN: **'视频的灯光脚本'**
+  ///
+  /// fi-FI: **'Näet lisää napauttamalla kuvakkeita'**
   static const test = 'test';
 
   /// Translations:
@@ -14,6 +19,10 @@ class LocalizationKeys {
   /// en:  **'Testing argument %1$s'**
   ///
   /// nl:  **'Test argument %1$s'**
+  ///
+  /// zh-Hans-CN: **'频的 %1$s'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$s'**
   static const testArg1 = 'test_arg1';
 
   /// Translations:
@@ -21,6 +30,10 @@ class LocalizationKeys {
   /// en:  **'Testing argument %1$d'**
   ///
   /// nl:  **'Test argument %1$d'**
+  ///
+  /// zh-Hans-CN: **'频的 %1$d'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$d'**
   static const testArg2 = 'test_arg2';
 
   /// Translations:
@@ -28,6 +41,10 @@ class LocalizationKeys {
   /// en:  **'Testing argument %1$s %2$d'**
   ///
   /// nl:  **'Test argument %1$s %2$d'**
+  ///
+  /// zh-Hans-CN: **'频的 %1$s %2$d'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$s %2$d'**
   static const testArg3 = 'test_arg3';
 
   /// Translations:
@@ -35,6 +52,10 @@ class LocalizationKeys {
   /// en:  **'Testing argument %1$s %2$d %1$s'**
   ///
   /// nl:  **'Test argument %1$s %2$d %1$s'**
+  ///
+  /// zh-Hans-CN: **'频的 %1$s %2$d %1$s'**
+  ///
+  /// fi-FI: **'Lisää napauttamalla %1$s %2$d %1$s'**
   static const testArg4 = 'test_arg4';
 
   /// Translations:
@@ -42,5 +63,10 @@ class LocalizationKeys {
   /// en:  **'Testing\nargument\n\n%1$s %2$d %1$s'**
   ///
   /// nl:  **'Test\nargument\n\n%1$s %2$d %1$s'**
+  ///
+  /// zh-Hans-CN: **'频\n的\n\n%1$s %2$d %1$s'**
+  ///
+  /// fi-FI: **'Lisää\nLisää napauttamalla\n\n%1$s %2$d %1$s'**
   static const testNewLine = 'test_new_line';
+
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.17.0
   provider: ^5.0.0
   shared_preferences: ^2.0.5
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  intl: ^0.17.0
   provider: ^5.0.0
   shared_preferences: ^2.0.5
 
@@ -24,7 +25,7 @@ flutter:
     - assets/locale/
 
 locale_gen:
-  languages: ['en','nl']
+  languages: ['en','nl', 'zh-Hans-CN', 'fi-FI']
 #  locale_assets_path: 'assets/localization'
 #  assets_path: 'assets/localization'
 #  doc_languages: ['en']

--- a/lib/src/locale_gen_parser.dart
+++ b/lib/src/locale_gen_parser.dart
@@ -1,0 +1,27 @@
+import 'package:intl/locale.dart';
+
+class LocaleGenParser {
+  const LocaleGenParser._();
+
+  static String parseSupportedLanguage(String language) {
+    try {
+      final locale = Locale.tryParse(language);
+      final languageCode = locale?.languageCode;
+      return "    '$languageCode',";
+    } catch (_) {
+      return "    '$language',";
+    }
+  }
+
+  static String parseSupportedLocale(String language) {
+    try {
+      final locale = Locale.tryParse(language);
+      final languageCode = locale?.languageCode;
+      final scriptCode = locale?.scriptCode;
+      final countryCode = locale?.countryCode;
+      return "    Locale.fromSubtags(languageCode: ${languageCode != null ? "'$languageCode'" : null}, scriptCode: ${scriptCode != null ? "'$scriptCode'" : null}, countryCode: ${countryCode != null ? "'$countryCode'" : null}),";
+    } catch (_) {
+      return "    Locale('$language'),";
+    }
+  }
+}

--- a/lib/src/locale_gen_writer.dart
+++ b/lib/src/locale_gen_writer.dart
@@ -85,7 +85,6 @@ class LocaleGenWriter {
     final sb = StringBuffer()
       ..writeln("import 'dart:convert';")
       ..writeln()
-      ..writeln("import 'package:intl/locale.dart';")
       ..writeln("import 'package:flutter/services.dart';")
       ..writeln("import 'package:flutter/widgets.dart';")
       ..writeln(

--- a/lib/src/locale_gen_writer.dart
+++ b/lib/src/locale_gen_writer.dart
@@ -26,7 +26,8 @@ class LocaleGenWriter {
       allTranslations[language] = translations;
     }
     if (defaultTranslations == null) {
-      throw Exception('${params.defaultLanguage} could not be used because it is not configured correctly');
+      throw Exception(
+          '${params.defaultLanguage} could not be used because it is not configured correctly');
     }
     _createLocalizationKeysFile(params, defaultTranslations, allTranslations);
     _createLocalizationFile(params, defaultTranslations, allTranslations);
@@ -34,8 +35,10 @@ class LocaleGenWriter {
     print('Done!!!');
   }
 
-  static Map<String, dynamic> getTranslations(LocaleGenParams params, String language) {
-    final translationFile = File(join(Directory.current.path, params.localeAssetsDir, '$language.json'));
+  static Map<String, dynamic> getTranslations(
+      LocaleGenParams params, String language) {
+    final translationFile = File(
+        join(Directory.current.path, params.localeAssetsDir, '$language.json'));
     if (!translationFile.existsSync()) {
       throw Exception('${translationFile.path} does not exists');
     }
@@ -44,22 +47,29 @@ class LocaleGenWriter {
     return jsonDecode(jsonString) as Map<String, dynamic>; // ignore: avoid_as
   }
 
-  static void _createLocalizationKeysFile(LocaleGenParams params, Map<String, dynamic> defaultTranslations, Map<String, Map<String, dynamic>> allTranslations) {
+  static void _createLocalizationKeysFile(
+      LocaleGenParams params,
+      Map<String, dynamic> defaultTranslations,
+      Map<String, Map<String, dynamic>> allTranslations) {
     final sb = StringBuffer()
-      ..writeln('//============================================================//')
+      ..writeln(
+          '//============================================================//')
       ..writeln('//THIS FILE IS AUTO GENERATED. DO NOT EDIT//')
-      ..writeln('//============================================================//')
+      ..writeln(
+          '//============================================================//')
       ..writeln('class LocalizationKeys {')
       ..writeln();
     defaultTranslations.forEach((key, value) {
-      TranslationWriter.buildDocumentation(sb, key, allTranslations, params.docLanguages);
+      TranslationWriter.buildDocumentation(
+          sb, key, allTranslations, params.docLanguages);
       final correctKey = CaseUtil.getCamelcase(key);
       sb..writeln('  static const $correctKey = \'$key\';')..writeln();
     });
     sb.writeln('}');
 
     // Write to file
-    final localizationKeysFile = File(join(Directory.current.path, params.outputDir, 'localization_keys.dart'));
+    final localizationKeysFile = File(join(
+        Directory.current.path, params.outputDir, 'localization_keys.dart'));
     if (!localizationKeysFile.existsSync()) {
       print('localization_keys.dart does not exists');
       print('Creating localization_keys.dart ...');
@@ -68,47 +78,61 @@ class LocaleGenWriter {
     localizationKeysFile.writeAsStringSync(sb.toString());
   }
 
-  static void _createLocalizationFile(LocaleGenParams params, Map<String, dynamic> defaultTranslations, Map<String, Map<String, dynamic>> allTranslations) {
+  static void _createLocalizationFile(
+      LocaleGenParams params,
+      Map<String, dynamic> defaultTranslations,
+      Map<String, Map<String, dynamic>> allTranslations) {
     final sb = StringBuffer()
       ..writeln("import 'dart:convert';")
       ..writeln()
       ..writeln("import 'package:flutter/services.dart';")
       ..writeln("import 'package:flutter/widgets.dart';")
-      ..writeln("import 'package:${params.projectName}/util/locale/localization_keys.dart';")
+      ..writeln(
+          "import 'package:${params.projectName}/util/locale/localization_keys.dart';")
       ..writeln()
-      ..writeln('//============================================================//')
+      ..writeln(
+          '//============================================================//')
       ..writeln('//THIS FILE IS AUTO GENERATED. DO NOT EDIT//')
-      ..writeln('//============================================================//')
+      ..writeln(
+          '//============================================================//')
       ..writeln('class Localization {')
-      ..writeln('  Map<String, dynamic> _localisedValues = <String, dynamic>{};')
+      ..writeln(
+          '  Map<String, dynamic> _localisedValues = <String, dynamic>{};')
       ..writeln()
-      ..writeln('  static Localization of(BuildContext context) => Localizations.of<Localization>(context, Localization)!;')
+      ..writeln(
+          '  static Localization of(BuildContext context) => Localizations.of<Localization>(context, Localization)!;')
       ..writeln()
-      ..writeln('  static Future<Localization> load(Locale locale, {bool showLocalizationKeys = false, bool useCaching = true}) async {')
+      ..writeln(
+          '  static Future<Localization> load(Locale locale, {bool showLocalizationKeys = false, bool useCaching = true}) async {')
       ..writeln('    final localizations = Localization();')
       ..writeln('    if (showLocalizationKeys) {')
       ..writeln('      return localizations;')
       ..writeln('    }')
-      ..writeln("    final jsonContent = await rootBundle.loadString('${params.assetsDir}\${locale.languageCode}.json', cache: useCaching);")
-      ..writeln('    localizations._localisedValues = json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as')
+      ..writeln(
+          "    final jsonContent = await rootBundle.loadString('${params.assetsDir}\${locale.languageCode}.json', cache: useCaching);")
+      ..writeln(
+          '    localizations._localisedValues = json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as')
       ..writeln('    return localizations;')
       ..writeln('  }')
       ..writeln()
       ..writeln('  String _t(String key, {List<dynamic>? args}) {')
       ..writeln('    try {')
-      ..writeln('      final value = _localisedValues[key] as String?; // ignore: avoid_as')
+      ..writeln(
+          '      final value = _localisedValues[key] as String?; // ignore: avoid_as')
       ..writeln("      if (value == null) return '\$key';")
       ..writeln('      if (args == null || args.isEmpty) return value;')
       ..writeln('      var newValue = value;')
       ..writeln('      // ignore: avoid_annotating_with_dynamic')
-      ..writeln('      args.asMap().forEach((index, dynamic arg) => newValue = _replaceWith(newValue, arg, index + 1));')
+      ..writeln(
+          '      args.asMap().forEach((index, dynamic arg) => newValue = _replaceWith(newValue, arg, index + 1));')
       ..writeln('      return newValue;')
       ..writeln('    } catch (e) {')
       ..writeln("      return '⚠\$key⚠';")
       ..writeln('    }')
       ..writeln('  }')
       ..writeln()
-      ..writeln('  String _replaceWith(String value, Object? arg, int argIndex) {')
+      ..writeln(
+          '  String _replaceWith(String value, Object? arg, int argIndex) {')
       ..writeln('    if (arg == null) return value;')
       ..writeln('    if (arg is String) {')
       ..writeln("      return value.replaceAll('%\$argIndex\\\$s', arg);")
@@ -119,13 +143,19 @@ class LocaleGenWriter {
       ..writeln('  }')
       ..writeln();
     defaultTranslations.forEach((key, value) {
-      TranslationWriter.buildDocumentation(sb, key, allTranslations, params.docLanguages);
+      TranslationWriter.buildDocumentation(
+          sb, key, allTranslations, params.docLanguages);
       TranslationWriter.buildTranslationFunction(sb, key, value);
     });
-    sb..writeln('  String getTranslation(String key, {List<dynamic>? args}) => _t(key, args: args ?? <dynamic>[]);')..writeln()..writeln('}');
+    sb
+      ..writeln(
+          '  String getTranslation(String key, {List<dynamic>? args}) => _t(key, args: args ?? <dynamic>[]);')
+      ..writeln()
+      ..writeln('}');
 
     // Write to file
-    final localizationFile = File(join(Directory.current.path, params.outputDir, 'localization.dart'));
+    final localizationFile = File(
+        join(Directory.current.path, params.outputDir, 'localization.dart'));
     if (!localizationFile.existsSync()) {
       print('localization.dart does not exists');
       print('Creating localization.dart ...');
@@ -140,32 +170,44 @@ class LocaleGenWriter {
       ..writeln()
       ..writeln("import 'package:flutter/foundation.dart';")
       ..writeln("import 'package:flutter/material.dart';")
-      ..writeln("import 'package:${params.projectName}/util/locale/localization.dart';")
+      ..writeln(
+          "import 'package:${params.projectName}/util/locale/localization.dart';")
       ..writeln()
-      ..writeln('//============================================================//')
+      ..writeln(
+          '//============================================================//')
       ..writeln('//THIS FILE IS AUTO GENERATED. DO NOT EDIT//')
-      ..writeln('//============================================================//')
+      ..writeln(
+          '//============================================================//')
       ..writeln()
       ..writeln('typedef LocaleFilter = bool Function(String languageCode);')
       ..writeln()
-      ..writeln('class LocalizationDelegate extends LocalizationsDelegate<Localization> {')
+      ..writeln(
+          'class LocalizationDelegate extends LocalizationsDelegate<Localization> {')
       ..writeln('  static LocaleFilter? localeFilter;')
-      ..writeln("  static const defaultLocale = Locale('${params.defaultLanguage}');")
+      ..writeln(
+          "  static const defaultLocale = Locale('${params.defaultLanguage}');")
       ..writeln('  static const _supportedLanguages = [');
-    params.languages.forEach((language) => sb.writeln(LocaleGenParser.parseSupportedLanguage(language)));
-    sb..writeln('  ];')..writeln()..writeln('  static const _supportedLocales = [');
-    params.languages.forEach((language) => sb.writeln(LocaleGenParser.parseSupportedLocale(language)));
+    params.languages.forEach((language) =>
+        sb.writeln(LocaleGenParser.parseSupportedLanguage(language)));
+    sb
+      ..writeln('  ];')
+      ..writeln()
+      ..writeln('  static const _supportedLocales = [');
+    params.languages.forEach((language) =>
+        sb.writeln(LocaleGenParser.parseSupportedLocale(language)));
     sb
       ..writeln('  ];')
       ..writeln()
       ..writeln('  static List<String> get supportedLanguages {')
       ..writeln('    if (localeFilter == null) return _supportedLanguages;')
-      ..writeln('    return _supportedLanguages.where((element) => localeFilter?.call(element) ?? true).toList();')
+      ..writeln(
+          '    return _supportedLanguages.where((element) => localeFilter?.call(element) ?? true).toList();')
       ..writeln('  }')
       ..writeln()
       ..writeln('  static List<Locale> get supportedLocales {')
       ..writeln('    if (localeFilter == null) return _supportedLocales;')
-      ..writeln('    return _supportedLocales.where((element) => localeFilter?.call(element.languageCode) ?? true).toList();')
+      ..writeln(
+          '    return _supportedLocales.where((element) => localeFilter?.call(element.languageCode) ?? true).toList();')
       ..writeln('  }')
       ..writeln()
       ..writeln('  Locale? newLocale;')
@@ -173,28 +215,33 @@ class LocaleGenWriter {
       ..writeln('  final bool useCaching;')
       ..writeln('  bool showLocalizationKeys;')
       ..writeln()
-      ..writeln('  LocalizationDelegate({this.newLocale, this.showLocalizationKeys = false, this.useCaching = !kDebugMode}) {')
+      ..writeln(
+          '  LocalizationDelegate({this.newLocale, this.showLocalizationKeys = false, this.useCaching = !kDebugMode}) {')
       ..writeln('    if (newLocale != null) {')
       ..writeln('      activeLocale = newLocale;')
       ..writeln('    }')
       ..writeln('  }')
       ..writeln()
       ..writeln('  @override')
-      ..writeln('  bool isSupported(Locale locale) => supportedLanguages.contains(locale.languageCode);')
+      ..writeln(
+          '  bool isSupported(Locale locale) => supportedLanguages.contains(locale.languageCode);')
       ..writeln()
       ..writeln('  @override')
       ..writeln('  Future<Localization> load(Locale locale) async {')
       ..writeln('    final newActiveLocale = newLocale ?? locale;')
       ..writeln('    activeLocale = newActiveLocale;')
-      ..writeln('    return Localization.load(newActiveLocale, showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);')
+      ..writeln(
+          '    return Localization.load(newActiveLocale, showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);')
       ..writeln('  }')
       ..writeln()
       ..writeln('  @override')
-      ..writeln('  bool shouldReload(LocalizationsDelegate<Localization> old) => true;')
+      ..writeln(
+          '  bool shouldReload(LocalizationsDelegate<Localization> old) => true;')
       ..writeln('}');
 
     // Write to file
-    final localizationDelegateFile = File(join(Directory.current.path, params.outputDir, 'localization_delegate.dart'));
+    final localizationDelegateFile = File(join(Directory.current.path,
+        params.outputDir, 'localization_delegate.dart'));
     if (!localizationDelegateFile.existsSync()) {
       print('localization_delegate.dart does not exists');
       print('Creating localization_delegate.dart ...');

--- a/lib/src/locale_gen_writer.dart
+++ b/lib/src/locale_gen_writer.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:intl/locale.dart';
 import 'package:locale_gen/src/case_util.dart';
 import 'package:path/path.dart';
 
@@ -84,6 +85,7 @@ class LocaleGenWriter {
     final sb = StringBuffer()
       ..writeln("import 'dart:convert';")
       ..writeln()
+      ..writeln("import 'package:intl/locale.dart';")
       ..writeln("import 'package:flutter/services.dart';")
       ..writeln("import 'package:flutter/widgets.dart';")
       ..writeln(
@@ -186,13 +188,13 @@ class LocaleGenWriter {
       ..writeln(
           "  static const defaultLocale = Locale('${params.defaultLanguage}');")
       ..writeln('  static const _supportedLanguages = [');
-    params.languages.forEach((language) => sb.writeln("    '$language',"));
+    params.languages.forEach((language) => sb.writeln(_parseSupportedLanguage(language)));
     sb
       ..writeln('  ];')
       ..writeln()
       ..writeln('  static const _supportedLocales = [');
     params.languages
-        .forEach((language) => sb.writeln("    Locale('$language'),"));
+        .forEach((language) => sb.writeln(_parseSupportedLocale(language)));
     sb
       ..writeln('  ];')
       ..writeln()
@@ -246,5 +248,27 @@ class LocaleGenWriter {
       localizationDelegateFile.createSync(recursive: true);
     }
     localizationDelegateFile.writeAsStringSync(sb.toString());
+  }
+
+  static String _parseSupportedLanguage(String language) {
+    try {
+      final locale = Locale.tryParse(language);
+      final languageCode = locale?.languageCode;
+      return "    '$languageCode',";
+    } catch (_) {
+      return "    '$language',";
+    }
+  }
+
+  static String _parseSupportedLocale(String language) {
+    try {
+      final locale = Locale.tryParse(language);
+      final languageCode = locale?.languageCode;
+      final scriptCode = locale?.scriptCode;
+      final countryCode = locale?.countryCode;
+        return "    Locale.fromSubtags(languageCode: ${languageCode != null ? "'$languageCode'" : null}, scriptCode: ${scriptCode != null ? "'$scriptCode'" : null}, countryCode: ${countryCode != null ? "'$countryCode'" : null}),";
+    } catch (_) {
+      return "    Locale('$language'),";
+    }
   }
 }

--- a/lib/src/locale_gen_writer.dart
+++ b/lib/src/locale_gen_writer.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:intl/locale.dart';
 import 'package:locale_gen/src/case_util.dart';
+import 'package:locale_gen/src/locale_gen_parser.dart';
 import 'package:path/path.dart';
 
 import 'locale_gen_params.dart';
@@ -26,8 +26,7 @@ class LocaleGenWriter {
       allTranslations[language] = translations;
     }
     if (defaultTranslations == null) {
-      throw Exception(
-          '${params.defaultLanguage} could not be used because it is not configured correctly');
+      throw Exception('${params.defaultLanguage} could not be used because it is not configured correctly');
     }
     _createLocalizationKeysFile(params, defaultTranslations, allTranslations);
     _createLocalizationFile(params, defaultTranslations, allTranslations);
@@ -35,10 +34,8 @@ class LocaleGenWriter {
     print('Done!!!');
   }
 
-  static Map<String, dynamic> getTranslations(
-      LocaleGenParams params, String language) {
-    final translationFile = File(
-        join(Directory.current.path, params.localeAssetsDir, '$language.json'));
+  static Map<String, dynamic> getTranslations(LocaleGenParams params, String language) {
+    final translationFile = File(join(Directory.current.path, params.localeAssetsDir, '$language.json'));
     if (!translationFile.existsSync()) {
       throw Exception('${translationFile.path} does not exists');
     }
@@ -47,29 +44,22 @@ class LocaleGenWriter {
     return jsonDecode(jsonString) as Map<String, dynamic>; // ignore: avoid_as
   }
 
-  static void _createLocalizationKeysFile(
-      LocaleGenParams params,
-      Map<String, dynamic> defaultTranslations,
-      Map<String, Map<String, dynamic>> allTranslations) {
+  static void _createLocalizationKeysFile(LocaleGenParams params, Map<String, dynamic> defaultTranslations, Map<String, Map<String, dynamic>> allTranslations) {
     final sb = StringBuffer()
-      ..writeln(
-          '//============================================================//')
+      ..writeln('//============================================================//')
       ..writeln('//THIS FILE IS AUTO GENERATED. DO NOT EDIT//')
-      ..writeln(
-          '//============================================================//')
+      ..writeln('//============================================================//')
       ..writeln('class LocalizationKeys {')
       ..writeln();
     defaultTranslations.forEach((key, value) {
-      TranslationWriter.buildDocumentation(
-          sb, key, allTranslations, params.docLanguages);
+      TranslationWriter.buildDocumentation(sb, key, allTranslations, params.docLanguages);
       final correctKey = CaseUtil.getCamelcase(key);
       sb..writeln('  static const $correctKey = \'$key\';')..writeln();
     });
     sb.writeln('}');
 
     // Write to file
-    final localizationKeysFile = File(join(
-        Directory.current.path, params.outputDir, 'localization_keys.dart'));
+    final localizationKeysFile = File(join(Directory.current.path, params.outputDir, 'localization_keys.dart'));
     if (!localizationKeysFile.existsSync()) {
       print('localization_keys.dart does not exists');
       print('Creating localization_keys.dart ...');
@@ -78,61 +68,47 @@ class LocaleGenWriter {
     localizationKeysFile.writeAsStringSync(sb.toString());
   }
 
-  static void _createLocalizationFile(
-      LocaleGenParams params,
-      Map<String, dynamic> defaultTranslations,
-      Map<String, Map<String, dynamic>> allTranslations) {
+  static void _createLocalizationFile(LocaleGenParams params, Map<String, dynamic> defaultTranslations, Map<String, Map<String, dynamic>> allTranslations) {
     final sb = StringBuffer()
       ..writeln("import 'dart:convert';")
       ..writeln()
       ..writeln("import 'package:flutter/services.dart';")
       ..writeln("import 'package:flutter/widgets.dart';")
-      ..writeln(
-          "import 'package:${params.projectName}/util/locale/localization_keys.dart';")
+      ..writeln("import 'package:${params.projectName}/util/locale/localization_keys.dart';")
       ..writeln()
-      ..writeln(
-          '//============================================================//')
+      ..writeln('//============================================================//')
       ..writeln('//THIS FILE IS AUTO GENERATED. DO NOT EDIT//')
-      ..writeln(
-          '//============================================================//')
+      ..writeln('//============================================================//')
       ..writeln('class Localization {')
-      ..writeln(
-          '  Map<String, dynamic> _localisedValues = <String, dynamic>{};')
+      ..writeln('  Map<String, dynamic> _localisedValues = <String, dynamic>{};')
       ..writeln()
-      ..writeln(
-          '  static Localization of(BuildContext context) => Localizations.of<Localization>(context, Localization)!;')
+      ..writeln('  static Localization of(BuildContext context) => Localizations.of<Localization>(context, Localization)!;')
       ..writeln()
-      ..writeln(
-          '  static Future<Localization> load(Locale locale, {bool showLocalizationKeys = false, bool useCaching = true}) async {')
+      ..writeln('  static Future<Localization> load(Locale locale, {bool showLocalizationKeys = false, bool useCaching = true}) async {')
       ..writeln('    final localizations = Localization();')
       ..writeln('    if (showLocalizationKeys) {')
       ..writeln('      return localizations;')
       ..writeln('    }')
-      ..writeln(
-          "    final jsonContent = await rootBundle.loadString('${params.assetsDir}\${locale.languageCode}.json', cache: useCaching);")
-      ..writeln(
-          '    localizations._localisedValues = json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as')
+      ..writeln("    final jsonContent = await rootBundle.loadString('${params.assetsDir}\${locale.languageCode}.json', cache: useCaching);")
+      ..writeln('    localizations._localisedValues = json.decode(jsonContent) as Map<String, dynamic>; // ignore: avoid_as')
       ..writeln('    return localizations;')
       ..writeln('  }')
       ..writeln()
       ..writeln('  String _t(String key, {List<dynamic>? args}) {')
       ..writeln('    try {')
-      ..writeln(
-          '      final value = _localisedValues[key] as String?; // ignore: avoid_as')
+      ..writeln('      final value = _localisedValues[key] as String?; // ignore: avoid_as')
       ..writeln("      if (value == null) return '\$key';")
       ..writeln('      if (args == null || args.isEmpty) return value;')
       ..writeln('      var newValue = value;')
       ..writeln('      // ignore: avoid_annotating_with_dynamic')
-      ..writeln(
-          '      args.asMap().forEach((index, dynamic arg) => newValue = _replaceWith(newValue, arg, index + 1));')
+      ..writeln('      args.asMap().forEach((index, dynamic arg) => newValue = _replaceWith(newValue, arg, index + 1));')
       ..writeln('      return newValue;')
       ..writeln('    } catch (e) {')
       ..writeln("      return '⚠\$key⚠';")
       ..writeln('    }')
       ..writeln('  }')
       ..writeln()
-      ..writeln(
-          '  String _replaceWith(String value, Object? arg, int argIndex) {')
+      ..writeln('  String _replaceWith(String value, Object? arg, int argIndex) {')
       ..writeln('    if (arg == null) return value;')
       ..writeln('    if (arg is String) {')
       ..writeln("      return value.replaceAll('%\$argIndex\\\$s', arg);")
@@ -143,19 +119,13 @@ class LocaleGenWriter {
       ..writeln('  }')
       ..writeln();
     defaultTranslations.forEach((key, value) {
-      TranslationWriter.buildDocumentation(
-          sb, key, allTranslations, params.docLanguages);
+      TranslationWriter.buildDocumentation(sb, key, allTranslations, params.docLanguages);
       TranslationWriter.buildTranslationFunction(sb, key, value);
     });
-    sb
-      ..writeln(
-          '  String getTranslation(String key, {List<dynamic>? args}) => _t(key, args: args ?? <dynamic>[]);')
-      ..writeln()
-      ..writeln('}');
+    sb..writeln('  String getTranslation(String key, {List<dynamic>? args}) => _t(key, args: args ?? <dynamic>[]);')..writeln()..writeln('}');
 
     // Write to file
-    final localizationFile = File(
-        join(Directory.current.path, params.outputDir, 'localization.dart'));
+    final localizationFile = File(join(Directory.current.path, params.outputDir, 'localization.dart'));
     if (!localizationFile.existsSync()) {
       print('localization.dart does not exists');
       print('Creating localization.dart ...');
@@ -170,44 +140,32 @@ class LocaleGenWriter {
       ..writeln()
       ..writeln("import 'package:flutter/foundation.dart';")
       ..writeln("import 'package:flutter/material.dart';")
-      ..writeln(
-          "import 'package:${params.projectName}/util/locale/localization.dart';")
+      ..writeln("import 'package:${params.projectName}/util/locale/localization.dart';")
       ..writeln()
-      ..writeln(
-          '//============================================================//')
+      ..writeln('//============================================================//')
       ..writeln('//THIS FILE IS AUTO GENERATED. DO NOT EDIT//')
-      ..writeln(
-          '//============================================================//')
+      ..writeln('//============================================================//')
       ..writeln()
       ..writeln('typedef LocaleFilter = bool Function(String languageCode);')
       ..writeln()
-      ..writeln(
-          'class LocalizationDelegate extends LocalizationsDelegate<Localization> {')
+      ..writeln('class LocalizationDelegate extends LocalizationsDelegate<Localization> {')
       ..writeln('  static LocaleFilter? localeFilter;')
-      ..writeln(
-          "  static const defaultLocale = Locale('${params.defaultLanguage}');")
+      ..writeln("  static const defaultLocale = Locale('${params.defaultLanguage}');")
       ..writeln('  static const _supportedLanguages = [');
-    params.languages
-        .forEach((language) => sb.writeln(_parseSupportedLanguage(language)));
-    sb
-      ..writeln('  ];')
-      ..writeln()
-      ..writeln('  static const _supportedLocales = [');
-    params.languages
-        .forEach((language) => sb.writeln(_parseSupportedLocale(language)));
+    params.languages.forEach((language) => sb.writeln(LocaleGenParser.parseSupportedLanguage(language)));
+    sb..writeln('  ];')..writeln()..writeln('  static const _supportedLocales = [');
+    params.languages.forEach((language) => sb.writeln(LocaleGenParser.parseSupportedLocale(language)));
     sb
       ..writeln('  ];')
       ..writeln()
       ..writeln('  static List<String> get supportedLanguages {')
       ..writeln('    if (localeFilter == null) return _supportedLanguages;')
-      ..writeln(
-          '    return _supportedLanguages.where((element) => localeFilter?.call(element) ?? true).toList();')
+      ..writeln('    return _supportedLanguages.where((element) => localeFilter?.call(element) ?? true).toList();')
       ..writeln('  }')
       ..writeln()
       ..writeln('  static List<Locale> get supportedLocales {')
       ..writeln('    if (localeFilter == null) return _supportedLocales;')
-      ..writeln(
-          '    return _supportedLocales.where((element) => localeFilter?.call(element.languageCode) ?? true).toList();')
+      ..writeln('    return _supportedLocales.where((element) => localeFilter?.call(element.languageCode) ?? true).toList();')
       ..writeln('  }')
       ..writeln()
       ..writeln('  Locale? newLocale;')
@@ -215,60 +173,33 @@ class LocaleGenWriter {
       ..writeln('  final bool useCaching;')
       ..writeln('  bool showLocalizationKeys;')
       ..writeln()
-      ..writeln(
-          '  LocalizationDelegate({this.newLocale, this.showLocalizationKeys = false, this.useCaching = !kDebugMode}) {')
+      ..writeln('  LocalizationDelegate({this.newLocale, this.showLocalizationKeys = false, this.useCaching = !kDebugMode}) {')
       ..writeln('    if (newLocale != null) {')
       ..writeln('      activeLocale = newLocale;')
       ..writeln('    }')
       ..writeln('  }')
       ..writeln()
       ..writeln('  @override')
-      ..writeln(
-          '  bool isSupported(Locale locale) => supportedLanguages.contains(locale.languageCode);')
+      ..writeln('  bool isSupported(Locale locale) => supportedLanguages.contains(locale.languageCode);')
       ..writeln()
       ..writeln('  @override')
       ..writeln('  Future<Localization> load(Locale locale) async {')
       ..writeln('    final newActiveLocale = newLocale ?? locale;')
       ..writeln('    activeLocale = newActiveLocale;')
-      ..writeln(
-          '    return Localization.load(newActiveLocale, showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);')
+      ..writeln('    return Localization.load(newActiveLocale, showLocalizationKeys: showLocalizationKeys, useCaching: useCaching);')
       ..writeln('  }')
       ..writeln()
       ..writeln('  @override')
-      ..writeln(
-          '  bool shouldReload(LocalizationsDelegate<Localization> old) => true;')
+      ..writeln('  bool shouldReload(LocalizationsDelegate<Localization> old) => true;')
       ..writeln('}');
 
     // Write to file
-    final localizationDelegateFile = File(join(Directory.current.path,
-        params.outputDir, 'localization_delegate.dart'));
+    final localizationDelegateFile = File(join(Directory.current.path, params.outputDir, 'localization_delegate.dart'));
     if (!localizationDelegateFile.existsSync()) {
       print('localization_delegate.dart does not exists');
       print('Creating localization_delegate.dart ...');
       localizationDelegateFile.createSync(recursive: true);
     }
     localizationDelegateFile.writeAsStringSync(sb.toString());
-  }
-
-  static String _parseSupportedLanguage(String language) {
-    try {
-      final locale = Locale.tryParse(language);
-      final languageCode = locale?.languageCode;
-      return "    '$languageCode',";
-    } catch (_) {
-      return "    '$language',";
-    }
-  }
-
-  static String _parseSupportedLocale(String language) {
-    try {
-      final locale = Locale.tryParse(language);
-      final languageCode = locale?.languageCode;
-      final scriptCode = locale?.scriptCode;
-      final countryCode = locale?.countryCode;
-      return "    Locale.fromSubtags(languageCode: ${languageCode != null ? "'$languageCode'" : null}, scriptCode: ${scriptCode != null ? "'$scriptCode'" : null}, countryCode: ${countryCode != null ? "'$countryCode'" : null}),";
-    } catch (_) {
-      return "    Locale('$language'),";
-    }
   }
 }

--- a/lib/src/locale_gen_writer.dart
+++ b/lib/src/locale_gen_writer.dart
@@ -188,7 +188,8 @@ class LocaleGenWriter {
       ..writeln(
           "  static const defaultLocale = Locale('${params.defaultLanguage}');")
       ..writeln('  static const _supportedLanguages = [');
-    params.languages.forEach((language) => sb.writeln(_parseSupportedLanguage(language)));
+    params.languages
+        .forEach((language) => sb.writeln(_parseSupportedLanguage(language)));
     sb
       ..writeln('  ];')
       ..writeln()
@@ -266,7 +267,7 @@ class LocaleGenWriter {
       final languageCode = locale?.languageCode;
       final scriptCode = locale?.scriptCode;
       final countryCode = locale?.countryCode;
-        return "    Locale.fromSubtags(languageCode: ${languageCode != null ? "'$languageCode'" : null}, scriptCode: ${scriptCode != null ? "'$scriptCode'" : null}, countryCode: ${countryCode != null ? "'$countryCode'" : null}),";
+      return "    Locale.fromSubtags(languageCode: ${languageCode != null ? "'$languageCode'" : null}, scriptCode: ${scriptCode != null ? "'$scriptCode'" : null}, countryCode: ${countryCode != null ? "'$countryCode'" : null}),";
     } catch (_) {
       return "    Locale('$language'),";
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  intl: ^0.17.0
   meta: ^1.3.0
   path: ^1.8.0
   yaml: ^3.1.0

--- a/test/locale_gen_parser_test.dart
+++ b/test/locale_gen_parser_test.dart
@@ -19,15 +19,18 @@ void main() {
   group('LocaleGen parseSupportedLocale', () {
     test('parses nl locale', () {
       final result = LocaleGenParser.parseSupportedLocale('nl');
-      expect(result, "    Locale.fromSubtags(languageCode: 'nl', scriptCode: null, countryCode: null),");
+      expect(result,
+          "    Locale.fromSubtags(languageCode: 'nl', scriptCode: null, countryCode: null),");
     });
     test('parses zh-Hans-CN locale', () {
       final result = LocaleGenParser.parseSupportedLocale('zh-Hans-CN');
-      expect(result, "    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'),");
+      expect(result,
+          "    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'),");
     });
     test('parses fi-FI locale', () {
       final result = LocaleGenParser.parseSupportedLocale('fi-FI');
-      expect(result, "    Locale.fromSubtags(languageCode: 'fi', scriptCode: null, countryCode: 'FI'),");
+      expect(result,
+          "    Locale.fromSubtags(languageCode: 'fi', scriptCode: null, countryCode: 'FI'),");
     });
   });
 }

--- a/test/locale_gen_parser_test.dart
+++ b/test/locale_gen_parser_test.dart
@@ -1,0 +1,33 @@
+import 'package:locale_gen/src/locale_gen_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LocaleGen parseSupportedLanguage', () {
+    test('parses nl locale', () {
+      final result = LocaleGenParser.parseSupportedLanguage('nl');
+      expect(result, "    'nl',");
+    });
+    test('parses zh-Hans-CN locale', () {
+      final result = LocaleGenParser.parseSupportedLanguage('zh-Hans-CN');
+      expect(result, "    'zh',");
+    });
+    test('parses fi-FI locale', () {
+      final result = LocaleGenParser.parseSupportedLanguage('fi-FI');
+      expect(result, "    'fi',");
+    });
+  });
+  group('LocaleGen parseSupportedLocale', () {
+    test('parses nl locale', () {
+      final result = LocaleGenParser.parseSupportedLocale('nl');
+      expect(result, "    Locale.fromSubtags(languageCode: 'nl', scriptCode: null, countryCode: null),");
+    });
+    test('parses zh-Hans-CN locale', () {
+      final result = LocaleGenParser.parseSupportedLocale('zh-Hans-CN');
+      expect(result, "    Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN'),");
+    });
+    test('parses fi-FI locale', () {
+      final result = LocaleGenParser.parseSupportedLocale('fi-FI');
+      expect(result, "    Locale.fromSubtags(languageCode: 'fi', scriptCode: null, countryCode: 'FI'),");
+    });
+  });
+}


### PR DESCRIPTION
For a project, we should be able to parse locales cfr 'zh-Hans-CN' and 'fi-FI'. This seemed not possible with the previous implementation, which treated the whole String as 'languageCode'. 

This fix should parse the different components as their respective actual properties. 

Fixed in #50 